### PR TITLE
RelayNext: Fix error when receiving PMs

### DIFF
--- a/RelayNext/plugin.py
+++ b/RelayNext/plugin.py
@@ -292,10 +292,10 @@ class RelayNext(callbacks.Plugin):
         return True
 
     def relay(self, irc, msg, channel, isAnnouncement=False):
-        channel = channel.lower()
         self.log.debug("RelayNext (%s): got channel %s", irc.network, channel)
         if not channel in irc.state.channels:
             return
+        channel = channel.lower()
 
         # Check for ignored events first. Checking for "'.' not in msg.nick" is for skipping
         # ignore checks from servers.


### PR DESCRIPTION
2bd13fa0680572c0940ab249d2aa693453aa1787 replaced `msg.args[0]` with `msg.channel`, but the latter is `None` on PMs.

Additionally, `irc.state.channels.__contains__` performs normalization itself (and using RFC1459 normalization rather than Unicode), so it is not needed to
normalize this early.